### PR TITLE
Change grep pattern

### DIFF
--- a/git-commands.js
+++ b/git-commands.js
@@ -5,7 +5,7 @@ const TAG_NOT_FOUND = 128;
 module.exports = {
   getLatestTag: (prefix) => {
     try {
-      const maybeGrepCommand = prefix !== '' ? `| grep "${prefix}*"` : '';
+      const maybeGrepCommand = prefix !== '' ? `| grep "^${prefix}"` : '';
       const stdout = exec(`git tag -l ${maybeGrepCommand} | sort -V | tail -n 1`);
       return String(stdout).trim();
     } catch (error) {


### PR DESCRIPTION
When `pattern` is one character long then `grep "${prefix}*"` returns all results. This is because `<char>*` means "zero or more <char>".